### PR TITLE
Ensure S&P 500 index is datetime before extracting date

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -34,6 +34,8 @@ sp500 = sp500.history(period="max")
 
 
 sp500 = sp500.loc["1990-01-01":].copy()
+# S'assure que l'index est bien au format datetime avant d'en extraire la date
+sp500.index = pd.to_datetime(sp500.index)
 sp500.index = sp500.index.date
 
 st.set_page_config(


### PR DESCRIPTION
## Summary
- ensure the S&P 500 index is converted to a DatetimeIndex before extracting the date component to avoid AttributeError on generic Index objects

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df93dfc114832184be6d30008b3bcf